### PR TITLE
多対多でイベントのタグを追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,7 +19,7 @@ class EventsController < ApplicationController
     @event.owner_id = current_user.id;
 
     tag_list = params[:event][:tag_names].split(",")
-  
+
     @event.tags_save(tag_list)
 
     if @event.save
@@ -33,6 +33,11 @@ class EventsController < ApplicationController
 
   def update
     @event = current_user.created_events.find(params[:id])
+    tag_list = params[:event][:tag_names].split(",")
+    # 空白文字の配列を取り除く https://qiita.com/ta1kt0me@github/items/33c4d37a65b69b75ee40
+    tag_list.reject(&:blank?)
+    # binding.pry
+    @event.tags_save(tag_list)
     if @event.update(event_params)
       redirect_to @event, notice: "更新しました"
     end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,7 +10,16 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = current_user.created_events.build(event_params)
+    # create_events.build を使いたいが、userとtagの結びつけ方が不明のため一旦スルー
+    # @event = current_user.created_events.build(event_params)
+
+    # create_events.build をスルーするための代わりのコード
+    @event = Event.new(event_params)
+    @event.owner_id = current_user.id;
+
+    tag_list = params[:event][:tag_names].split(",")
+  
+    @event.tags_save(tag_list)
 
     if @event.save
       redirect_to @event, notice: "作成しました"
@@ -38,7 +47,7 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(
-      :name, :place, :image, :remove_image, :content, :start_at, :end_at
+      :name, :place, :image, :remove_image, :content, :start_at, :end_at, :tag_name
     )
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,6 +4,7 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
     @ticket = current_user && current_user.tickets.find_by(event: @event)
     @tickets = @event.tickets.includes(:user).order(:created_at)
+    # binding.pry
   end
   def new
     @event = current_user.created_events.build

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,6 +5,9 @@ class Event < ApplicationRecord
   # event.owner.name でownerの情報を参照できるようになる
   belongs_to :owner, class_name: "User"
 
+  has_many :event_tags
+  has_many :tags, through: :event_tags, source: :tag
+
   validates :image, content_type: [:png, :jpg, :jpeg], size: { less_than_or_equal_to: 10.megabytes }, dimension: { width: { max: 2000 } , height: { max: 2000 } }
 
   validates :name, length: { maximum: 50}, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,7 +6,7 @@ class Event < ApplicationRecord
   belongs_to :owner, class_name: "User"
 
   has_many :event_tags
-  has_many :tags, through: :event_tags, source: :tag
+  has_many :tags, through: :event_tags
 
   validates :image, content_type: [:png, :jpg, :jpeg], size: { less_than_or_equal_to: 10.megabytes }, dimension: { width: { max: 2000 } , height: { max: 2000 } }
 
@@ -20,6 +20,17 @@ class Event < ApplicationRecord
   def created_by?(user)
     return false unless user
     owner_id == user.id
+  end
+
+  def tags_save(tag_list)
+    if self.tags != nil
+      event_tags_records = EventTag.where(event_id: self.id)
+      event_tags_records.destroy_all
+    end
+    tag_list.each do |tag|
+      inspected_tag = Tag.where(tag_name: tag).first_or_create
+      self.tags << inspected_tag
+    end
   end
 
   attr_accessor :remove_image

--- a/app/models/event_tag.rb
+++ b/app/models/event_tag.rb
@@ -1,0 +1,4 @@
+class EventTag < ApplicationRecord
+  belongs_to :event
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ApplicationRecord
+  has_many :event_tags
+  has_many :events, through: :event_tags
+end

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -19,6 +19,9 @@
       %div
         = f.datetime_select :end_at, start_year: now.year, end_year: now.year + 1
     .form-group
+      = f.label :tag_names
+      = f.text_field  @event.tags, placeholder:",で区切ってください"
+    .form-group
       = f.label :content
       = f.rich_text_area :content
     .form-group

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -20,7 +20,10 @@
         = f.datetime_select :end_at, start_year: now.year, end_year: now.year + 1
     .form-group
       = f.label :tag_names
-      = f.text_field  @event.tags, placeholder:",で区切ってください"
+      -# strip! で空白を削除
+      -# https://www.javadrive.jp/ruby/string_class/index11.html
+      - tags_array = @event.tags.map{|tag| "#{tag.tag_name.strip}," }
+      = f.text_field :tag_names, value: tags_array, placeholder:",で区切ってください", class: "form-control"
     .form-group
       = f.label :content
       = f.rich_text_area :content

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -23,7 +23,7 @@
       = f.rich_text_area :content
     .form-group
       = f.label :tag_names
-      = f.text_field :tag_names, placeholder:",で区切ってください"
+      = f.text_field :tag_names, placeholder:",で区切ってください", class: "form-control"
     .form-group
       = f.label :image
       = f.file_field :image, class: "form-control-file"

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -22,6 +22,9 @@
       = f.label :content
       = f.rich_text_area :content
     .form-group
+      = f.label :tag_names
+      = f.text_field :tag_names, placeholder:",で区切ってください"
+    .form-group
       = f.label :image
       = f.file_field :image, class: "form-control-file"
     = f.submit class: "btn btn-primary"

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -4,6 +4,13 @@
     .card.mb-2
       -if @event.image.attached?
         = image_tag @event.image, class: "card-img-top"
+
+    .card.mb-2
+      %h5.card-header  タグ
+      %p.card-body
+        - @event.tags.each do |tag|
+          %span
+            = "#{tag.tag_name},"
     .card.mb-2
       %h5.card-header イベント内容
       .card-body

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -8,9 +8,12 @@
     .card.mb-2
       %h5.card-header  タグ
       %p.card-body
-        - @event.tags.each do |tag|
-          %span
-            = "#{tag.tag_name},"
+        -# - @event.tags.each do |tag|
+        -#   %span
+        -#     = "#{tag.tag_name},"
+        - @event.tags.map do |tag|
+          %button{class: 'btn btn-secondary btn-sm'}
+            = "#{tag.tag_name.strip}"
     .card.mb-2
       %h5.card-header イベント内容
       .card-body

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -5,3 +5,8 @@
     = link_to(event, class: "list-group-item list-group-item-action") do
       %h5.list-group-item-heading= event.name
       %p.mb-1= "#{l(event.start_at, format: :long)} - #{l(event.end_at, format: :long)}"
+      - if !!event.tags
+        %p.mb-1
+          - event.tags.map do |tag|
+            %button{class: 'btn btn-secondary btn-sm'}
+              = "#{tag.tag_name.strip}"

--- a/db/migrate/20210608094428_create_tags.rb
+++ b/db/migrate/20210608094428_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tags do |t|
+      t.string :tag_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210608094439_create_event_tags.rb
+++ b/db/migrate/20210608094439_create_event_tags.rb
@@ -1,0 +1,10 @@
+class CreateEventTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :event_tags do |t|
+      t.references :event, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_04_110442) do
+ActiveRecord::Schema.define(version: 2021_06_08_094439) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -43,6 +43,15 @@ ActiveRecord::Schema.define(version: 2021_06_04_110442) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "event_tags", force: :cascade do |t|
+    t.integer "event_id", null: false
+    t.integer "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_event_tags_on_event_id"
+    t.index ["tag_id"], name: "index_event_tags_on_tag_id"
+  end
+
   create_table "events", force: :cascade do |t|
     t.integer "owner_id"
     t.string "name", null: false
@@ -52,6 +61,12 @@ ActiveRecord::Schema.define(version: 2021_06_04_110442) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["owner_id"], name: "index_events_on_owner_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "tag_name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "tickets", force: :cascade do |t|
@@ -75,5 +90,7 @@ ActiveRecord::Schema.define(version: 2021_06_04_110442) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "event_tags", "events"
+  add_foreign_key "event_tags", "tags"
   add_foreign_key "tickets", "events"
 end

--- a/test/fixtures/event_tags.yml
+++ b/test/fixtures/event_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  event: one
+  tag: one
+
+two:
+  event: two
+  tag: two

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  tag_name: MyString
+
+two:
+  tag_name: MyString

--- a/test/models/event_tag_test.rb
+++ b/test/models/event_tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
参考
https://post-output.com/185/

https://railsguides.jp/association_basics.html


■ハマったところ

Eventモデルで

```
@event = current_user.created_events.build(event_params)
```
としていたが、created_events はUserモデルで定義しているため、
create実行時に
ActiveModel::UnknownAttributeError (unknown attribute 'tag_name' for Event.):

が出ていた。一旦、Eventモデルの created_event コメントアウトして、
```
@event = Event.new(event_params)
@event.owner_id = current_user.id;
```
で代用、保存できるようになった


■試したこと

-工程を最初からやり直す
変わらず


- foreign_key　をつけてみる
```
class Event < ApplicationRecord
    has_many :tags, through: :event_tags, source: :tag , foreign_key: 'tag_name'
```
原因がUserモデルで作られているメソッドのため、NG

- binding.pry でのデバッグ
EventController の create アクション内で、どこで止まっているかをトライ＆エラー

@event = current_user.created_events.build(event_params) の箇所で特定



■[WIP]

editのviewでの表示が途中
